### PR TITLE
Add Plone 5.1 support.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,10 @@ Setup some testing stuff:
     >>> from collective.mtrsetup.tests.base import purge_registry
     >>> from collective.mtrsetup.tests.base import import_mimetypes_registry
     >>> from collective.mtrsetup.tests.base import export_mimetypes_registry
-    >>> registry = self.portal.mimetypes_registry
+    >>> from zope.component.hooks import getSite
+
+    >>> portal = getSite()
+    >>> registry = portal.mimetypes_registry
     >>> purge_registry(registry)
     >>> len(registry.mimetypes())
     0

--- a/collective/mtrsetup/tests/profile.txt
+++ b/collective/mtrsetup/tests/profile.txt
@@ -1,10 +1,12 @@
 collective.mtrsetup is a GenericSetup extension that provides import / export support for the mimetypes_registry.
 
 
->>> mr = self.portal.mimetypes_registry
+>>> from zope.component.hooks import getSite
+>>> portal = getSite()
+>>> mr = portal.mimetypes_registry
 >>> pre_mimetypes = mr.mimetypes()[:]
 
->>> setup = self.portal.portal_setup
+>>> setup = portal.portal_setup
 >>> profile_id = 'profile-collective.mtrsetup.tests:test'
 >>> setup.runImportStepFromProfile(profile_id, 'mimetypes')
 {...}

--- a/collective/mtrsetup/tests/test_doctest.py
+++ b/collective/mtrsetup/tests/test_doctest.py
@@ -1,28 +1,21 @@
-import unittest
+from collective.mtrsetup.tests.base import MTRSETUP_INTEGRATION_TESTING
+from plone.testing import layered
 import doctest
+import unittest
 
-#from zope.testing import doctestunit
-#from zope.component import testing, eventtesting
 
-from Testing import ZopeTestCase as ztc
+FLAGS = doctest.REPORT_ONLY_FIRST_FAILURE | doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS
 
-from collective.mtrsetup.tests import base
-
-functionl_doctest_files = [
-    '../../README.rst',
-    'tests/profile.txt',
-    ]
 
 def test_suite():
-    return unittest.TestSuite([
-            # Demonstrate the main content types
-            ztc.ZopeDocFileSuite(
-                file_, package='collective.mtrsetup',
-                test_class=base.FunctionalTestCase,
-                optionflags=doctest.REPORT_ONLY_FIRST_FAILURE |
-                doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS)
-            for file_ in functionl_doctest_files
-            ])
+
+    suite = unittest.TestSuite()
+    suite.addTests([
+        layered(doctest.DocFileSuite('../../../README.rst', optionflags=FLAGS), layer=MTRSETUP_INTEGRATION_TESTING),
+        layered(doctest.DocFileSuite('../tests/profile.txt', optionflags=FLAGS), layer=MTRSETUP_INTEGRATION_TESTING),
+    ])
+    return suite
+
 
 if __name__ == '__main__':
     unittest.main(defaultTest='test_suite')

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,8 +4,8 @@ Changelog
 1.5.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Add Plone 5.1 support by replacing the old PloneTestCase with plone.app.testing [mathias.leimgruber]
+- Drop Plone 4.1 support [mathias.leimgruber]
 
 1.5.4 (2017-07-31)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ version = '1.5.5.dev0'
 tests_require = [
     'Plone',
     'zope.testing',
-    'Products.PloneTestCase',
+    'plone.app.testing',
     ]
 
 setup(name='collective.mtrsetup',
@@ -16,6 +16,9 @@ setup(name='collective.mtrsetup',
           open(os.path.join("docs", "HISTORY.txt")).read(),
       # Get more strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
       classifiers=[
+        "Framework :: Plone :: 4.2",
+        "Framework :: Plone :: 4.3",
+        "Framework :: Plone :: 5.1",
         "Programming Language :: Python",
         ],
       keywords='generic setup gs mimetypes registry import export',

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.1.x.cfg
-
-package-name = collective.mtrsetup

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.1.x.cfg
+
+package-name = collective.mtrsetup


### PR DESCRIPTION
I basically just replaces the old PloneTestCase with plone.app.testing layer.

Apparently tests are not running by a test server:

Plone 5.1:

```
./bin/test
Running collective.mtrsetup.tests.base.collective.mtrsetup:Integration tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.179 seconds.
  Set up plone.app.testing.layers.PloneFixture in 7.453 seconds.
  Set up collective.mtrsetup.tests.base.MtrsetupLayer Could not install product collective.mtrsetup
in 0.770 seconds.
  Set up collective.mtrsetup.tests.base.collective.mtrsetup:Integration in 0.000 seconds.
  Running:

  Ran 2 tests with 0 failures, 0 errors, 0 skipped in 0.195 seconds.
Tearing down left over layers:
  Tear down collective.mtrsetup.tests.base.collective.mtrsetup:Integration in 0.000 seconds.
  Tear down collective.mtrsetup.tests.base.MtrsetupLayer in 0.007 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.120 seconds.
  Tear down plone.testing.z2.Startup in 0.009 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.000 seconds.
```


Plone 4.3:

```
./bin/test 
Running collective.mtrsetup.tests.base.collective.mtrsetup:Integration tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.210 seconds.
  Set up plone.app.testing.layers.PloneFixture in 10.748 seconds.
  Set up collective.mtrsetup.tests.base.MtrsetupLayer Could not install product collective.mtrsetup
in 0.924 seconds.
  Set up collective.mtrsetup.tests.base.collective.mtrsetup:Integration in 0.000 seconds.
  Running:

  Ran 2 tests with 0 failures, 0 errors, 0 skipped in 0.170 seconds.
Tearing down left over layers:
  Tear down collective.mtrsetup.tests.base.collective.mtrsetup:Integration in 0.000 seconds.
  Tear down collective.mtrsetup.tests.base.MtrsetupLayer in 0.003 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.103 seconds.
  Tear down plone.testing.z2.Startup in 0.009 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.003 seconds.
```

Plone 4.2 with some nois:

``` 
./bin/test                                                                              ~/pkgs/collective.mtrsetup
/Users/maethu/dotfiles/.buildout/eggs/RestrictedPython-3.6.0-py2.7.egg/RestrictedPython/SelectCompiler.py:17: DeprecationWarning: The compiler package is deprecated and removed in Python 3.x.
  import compiler
/Users/maethu/dotfiles/.buildout/eggs/plone.testing-4.0.8-py2.7.egg/plone/testing/z2.py:19: DeprecationWarning: Zope2VocabularyRegistry is deprecated. Please import from Zope2.App.schema
  from Products.Five.schema import Zope2VocabularyRegistry
/Users/maethu/dotfiles/.buildout/eggs/Products.GenericSetup-1.7.3-py2.7.egg/Products/GenericSetup/registry.py:16: ImportWarning: Not importing directory '/Users/maethu/dotfiles/.buildout/eggs/Products.GenericSetup-1.7.3-py2.7.egg/Products/GenericSetup/xml': missing __init__.py
  from xml.sax import parseString
Running collective.mtrsetup.tests.base.collective.mtrsetup:Integration tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup /Users/maethu/dotfiles/.buildout/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/config.py:193: DeprecationWarning: FiveSecurityPolicy is deprecated. Please import from AccessControl.security
  obj = getattr(mod, oname)
in 0.219 seconds.
  Set up plone.app.testing.layers.PloneFixture /Users/maethu/dotfiles/.buildout/eggs/Products.Marshall-2.1.2-py2.7.egg/Products/Marshall/config.py:40: ImportWarning: Not importing directory '/Users/maethu/dotfiles/.buildout/eggs/Products.Marshall-2.1.2-py2.7.egg/Products/Marshall/xml': missing __init__.py
  from xml.etree import cElementTree
/Users/maethu/dotfiles/.buildout/eggs/Products.Marshall-2.1.2-py2.7.egg/Products/Marshall/handlers/atxml.py:59: ImportWarning: Not importing directory '/Users/maethu/dotfiles/.buildout/eggs/Products.Marshall-2.1.2-py2.7.egg/Products/Marshall/utils': missing __init__.py
  from Products.Marshall import utils
/Users/maethu/dotfiles/.buildout/eggs/Products.DCWorkflow-2.2.4-py2.7.egg/Products/DCWorkflow/exportimport.py:19: ImportWarning: Not importing directory '/Users/maethu/dotfiles/.buildout/eggs/Products.DCWorkflow-2.2.4-py2.7.egg/Products/DCWorkflow/xml': missing __init__.py
  from xml.dom.minidom import parseString
/Users/maethu/dotfiles/.buildout/eggs/Products.PluggableAuthService-1.10.0-py2.7.egg/Products/PluggableAuthService/plugins/exportimport.py:60: ImportWarning: Not importing directory '/Users/maethu/dotfiles/.buildout/eggs/Products.PluggableAuthService-1.10.0-py2.7.egg/Products/PluggableAuthService/plugins/xml': missing __init__.py
  from xml.dom.minidom import parseString
/Users/maethu/dotfiles/.buildout/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/config.py:179: ImportWarning: Not importing directory '/Users/maethu/dotfiles/.buildout/eggs/plone.z3cform-0.7.8-py2.7.egg/plone/z3cform/templates': missing __init__.py
  mod = __import__(mname, *_import_chickens)
/Users/maethu/dotfiles/.buildout/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/config.py:179: ImportWarning: Not importing directory '/Users/maethu/dotfiles/.buildout/eggs/plone.app.z3cform-0.6.2-py2.7.egg/plone/app/z3cform/templates': missing __init__.py
  mod = __import__(mname, *_import_chickens)
in 7.585 seconds.
  Set up collective.mtrsetup.tests.base.MtrsetupLayer Could not install product collective.mtrsetup
in 0.749 seconds.
  Set up collective.mtrsetup.tests.base.collective.mtrsetup:Integration in 0.000 seconds.
  Running:

  Ran 2 tests with 0 failures, 0 errors, 0 skipped in 0.151 seconds.
Tearing down left over layers:
  Tear down collective.mtrsetup.tests.base.collective.mtrsetup:Integration in 0.000 seconds.
  Tear down collective.mtrsetup.tests.base.MtrsetupLayer in 0.010 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.104 seconds.
  Tear down plone.testing.z2.Startup in 0.006 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.001 seconds
```


I dropped Plone 4.1 support, since I was not able to get the buildout working. 